### PR TITLE
No need for `unsafe` & `static mut`

### DIFF
--- a/src/auth_action.rs
+++ b/src/auth_action.rs
@@ -73,10 +73,7 @@ impl AuthAction {
                 debug!("process_response(auth): received OkHttpResponse");
 
                 // Increment authorized calls metric
-                crate::metrics::increment_authorized_calls();
-
-                // Increment user/group specific authorized calls metric
-                crate::metrics::increment_authorized_calls_with_user_group(&self.scope);
+                crate::metrics::get_metrics().increment_authorized_calls(&self.scope);
 
                 if !ok_response.get_response_headers_to_add().is_empty() {
                     warn!("process_response(auth): Unsupported field 'response_headers_to_add' in OkHttpResponse");

--- a/src/filter/kuadrant_filter.rs
+++ b/src/filter/kuadrant_filter.rs
@@ -300,11 +300,6 @@ impl HttpContext for KuadrantFilter {
         );
         self.phase = Phase::ResponseBody;
 
-        // Process token usage from response body if this is the end of stream
-        if end_of_stream {
-            crate::metrics::process_response_body_for_token_usage(&self.scope_for_metrics);
-        }
-
         // Need to check if there is something to do before expending
         // time and resources reading the body
         match self.response_body_receiver.take() {
@@ -351,6 +346,10 @@ impl HttpContext for KuadrantFilter {
                             );
                             self.path_store
                                 .insert_path("@kuadrant.response\\.body".into(), body_str.into());
+
+                            // Process token usage from response body if this is the end of stream
+                            crate::metrics::process_response_body_for_token_usage(&self.scope_for_metrics);
+
                             self.run(action_set, index)
                         }
                     },

--- a/src/filter/root_context.rs
+++ b/src/filter/root_context.rs
@@ -30,7 +30,7 @@ impl RootContext for FilterRoot {
             self.context_id, WASM_SHIM_HEADER, full_version
         );
 
-        crate::metrics::initialize_metrics();
+        // crate::metrics::initialize_metrics(); // this should happen conditionally
 
         true
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,7 +6,6 @@ mod configuration;
 mod data;
 #[allow(
     renamed_and_removed_lints,
-    mismatched_lifetime_syntaxes,
     clippy::panic,
     clippy::unwrap_used
 )]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1,96 +1,216 @@
 use log::error;
 use proxy_wasm::hostcalls;
 use std::collections::HashMap;
+use std::string::ToString;
+use std::sync::{OnceLock, RwLock};
+use std::sync::atomic::{AtomicBool, Ordering};
 
-// Simple metric IDs
-static mut AUTHORIZED_CALLS_METRIC_ID: Option<u32> = None;
-static mut LIMITED_CALLS_METRIC_ID: Option<u32> = None;
-static mut TOKEN_USAGE_METRIC_ID: Option<u32> = None;
+pub trait Metrics {
+    fn increment_authorized_calls(&self, _scope: &str) {}
+    fn increment_limited_calls(&self, _scope: &str) {}
 
-// Storage for user/group specific metrics
-static mut USER_GROUP_METRICS: Option<HashMap<String, u32>> = None;
+    fn increment_token_usage(&self, _scope: &str, _tokens: i64) {}
 
-pub fn initialize_metrics() {
-    // Initialize user/group metrics storage
-    unsafe {
-        USER_GROUP_METRICS = Some(HashMap::new());
-    }
-
-    // Authorized calls counter
-    match hostcalls::define_metric(
-        proxy_wasm::types::MetricType::Counter,
-        "authorized_calls_total",
-    ) {
-        Ok(metric_id) => unsafe {
-            AUTHORIZED_CALLS_METRIC_ID = Some(metric_id);
-        },
-        Err(e) => {
-            error!("Failed to define authorized_calls_total metric: {:?}", e);
-        }
-    }
-
-    // Limited calls counter
-    match hostcalls::define_metric(
-        proxy_wasm::types::MetricType::Counter,
-        "limited_calls_total",
-    ) {
-        Ok(metric_id) => unsafe {
-            LIMITED_CALLS_METRIC_ID = Some(metric_id);
-        },
-        Err(e) => {
-            error!("Failed to define limited_calls_total metric: {:?}", e);
-        }
-    }
-
-    // Token usage counter
-    match hostcalls::define_metric(proxy_wasm::types::MetricType::Counter, "token_usage_total") {
-        Ok(metric_id) => unsafe {
-            TOKEN_USAGE_METRIC_ID = Some(metric_id);
-        },
-        Err(e) => {
-            error!("Failed to define token_usage_total metric: {:?}", e);
-        }
+    fn is_enabled(&self) -> bool {
+        false
     }
 }
 
-pub fn increment_authorized_calls() {
-    unsafe {
-        if let Some(metric_id) = AUTHORIZED_CALLS_METRIC_ID {
+struct NoopMetrics {}
+
+impl Metrics for NoopMetrics {}
+
+struct HostMetrics {
+    enabled: AtomicBool,
+    metrics: RwLock<HashMap<String, u32>>,
+}
+
+impl HostMetrics {
+
+    const AUTHORIZED_CALLS_METRIC_ID: &'static str = "authorized_calls_total";
+    const LIMITED_CALLS_METRIC_ID: &'static str = "limited_calls_total";
+    const TOKEN_USAGE_METRIC_ID: &'static str = "token_usage_total";
+
+    pub fn new() -> Self {
+        let mut metrics = HashMap::new();
+
+        for name in [Self::AUTHORIZED_CALLS_METRIC_ID, Self::LIMITED_CALLS_METRIC_ID, Self::TOKEN_USAGE_METRIC_ID] {
+            match hostcalls::define_metric(proxy_wasm::types::MetricType::Counter, name) {
+                Ok(metric_id) => {
+                    metrics.insert(Self::AUTHORIZED_CALLS_METRIC_ID.to_string(), metric_id);
+                }
+                Err(e) => error!("Failed to define {name} metric: {e:?}"),
+            }
+        }
+
+        Self {
+            enabled: AtomicBool::new(true),
+            metrics: RwLock::new(metrics),
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn enable(&self) {
+        self.enabled.store(true, Ordering::Release);
+    }
+
+    #[allow(dead_code)]
+    pub fn disable(&self) {
+        self.enabled.store(true, Ordering::Release);
+    }
+
+    fn try_offset_counter(&self, name: &str, offset: i64) {
+        if self.is_enabled() {
+            if let Ok(metrics) = self.metrics.read() {
+                if let Some(metric) = metrics.get(name) {
+                    if let Err(e) = hostcalls::increment_metric(*metric, offset) {
+                        error!("Failed to increment `{name}` metric: {e:?}");
+                    }
+                }
+            }
+        }
+    }
+
+    fn increment_authorized_calls_with_user_group(&self, scope: &str) {
+        let (user_id, group) = extract_user_info();
+
+        if user_id == "unknown" || group == "unknown" {
+            return;
+        }
+
+        let namespace = extract_namespace_from_scope(scope);
+
+        if let Some(metric_id) = self.get_or_create_user_group_metric(
+            "authorized_calls_with_user_and_group",
+            &user_id,
+            &group,
+            &namespace,
+        ) {
             match hostcalls::increment_metric(metric_id, 1) {
                 Ok(_) => {}
-                Err(e) => error!("Failed to increment authorized_calls_total metric: {:?}", e),
+                Err(e) => error!(
+                "Failed to increment authorized_calls_with_user_and_group: {:?}",
+                e
+            ),
             }
-        } else {
-            error!("Authorized calls metric not initialized");
         }
     }
-}
 
-pub fn increment_limited_calls() {
-    unsafe {
-        if let Some(metric_id) = LIMITED_CALLS_METRIC_ID {
+    fn increment_limited_calls_with_user_group(&self, scope: &str) {
+        let (user_id, group) = extract_user_info();
+
+        if user_id == "unknown" || group == "unknown" {
+            return;
+        }
+
+        let namespace = extract_namespace_from_scope(scope);
+
+        if let Some(metric_id) = self.get_or_create_user_group_metric(
+            "limited_calls_with_user_and_group",
+            &user_id,
+            &group,
+            &namespace,
+        ) {
             match hostcalls::increment_metric(metric_id, 1) {
                 Ok(_) => {}
-                Err(e) => error!("Failed to increment limited_calls_total metric: {:?}", e),
+                Err(e) => error!(
+                "Failed to increment limited_calls_with_user_and_group: {:?}",
+                e
+            ),
             }
-        } else {
-            error!("Limited calls metric not initialized");
         }
     }
-}
 
-pub fn increment_token_usage(tokens: i64) {
-    unsafe {
-        if let Some(metric_id) = TOKEN_USAGE_METRIC_ID {
+    fn increment_token_usage_with_user_group(&self, scope: &str, tokens: i64) {
+        let (user_id, group) = extract_user_info();
+
+        if user_id == "unknown" || group == "unknown" {
+            return;
+        }
+
+        let namespace = extract_namespace_from_scope(scope);
+
+        if let Some(metric_id) = self.get_or_create_user_group_metric(
+            "token_usage_with_user_and_group",
+            &user_id,
+            &group,
+            &namespace,
+        ) {
             match hostcalls::increment_metric(metric_id, tokens) {
                 Ok(_) => {}
-                Err(e) => error!("Failed to increment token_usage_total metric: {:?}", e),
+                Err(e) => error!(
+                "Failed to increment token_usage_with_user_and_group: {:?}",
+                e
+            ),
+            }
+        }
+    }
+
+    fn get_or_create_user_group_metric(
+        &self,
+        metric_type: &str,
+        user: &str,
+        group: &str,
+        namespace: &str,
+    ) -> Option<u32> {
+        // Format: metric_type__user__USER__group__GROUP__namespace__NAMESPACE
+        let metric_name =
+            format!("{metric_type}__user__{user}__group__{group}__namespace__{namespace}");
+
+        let map_key = format!("{metric_type}:{user}:{group}:{namespace}");
+
+        if let Ok(ref mut metrics_map) = self.metrics.write() {
+            if let Some(&metric_id) = metrics_map.get(&map_key) {
+                return Some(metric_id);
+            }
+
+            // Create new metric
+            match hostcalls::define_metric(proxy_wasm::types::MetricType::Counter, &metric_name) {
+                Ok(metric_id) => {
+                    metrics_map.insert(map_key, metric_id);
+                    Some(metric_id)
+                }
+                Err(e) => {
+                    error!(
+                    "Failed to define user/group metric {}: {:?}",
+                    metric_name, e
+                );
+                    None
+                }
             }
         } else {
-            error!("Token usage metric not initialized");
+            error!("User/group metrics poisoned!");
+            None
         }
     }
 }
+
+impl Metrics for HostMetrics {
+    fn increment_authorized_calls(&self, scope: &str) {
+        self.try_offset_counter(Self::AUTHORIZED_CALLS_METRIC_ID, 1);
+        self.increment_authorized_calls_with_user_group(scope);
+    }
+    fn increment_limited_calls(&self, scope: &str) {
+        self.try_offset_counter(Self::LIMITED_CALLS_METRIC_ID, 1);
+        self.increment_limited_calls_with_user_group(scope);
+    }
+
+    fn increment_token_usage(&self, scope: &str, tokens: i64) {
+        self.try_offset_counter(Self::TOKEN_USAGE_METRIC_ID, tokens);
+        self.increment_token_usage_with_user_group(scope, tokens);
+    }
+
+    fn is_enabled(&self) -> bool {
+        self.enabled.load(Ordering::Acquire)
+    }
+}
+
+static METRICS: OnceLock<Box<dyn Metrics + Sync + Send>> = OnceLock::new();
+
+pub fn get_metrics() -> &'static dyn Metrics {
+    METRICS.get_or_init(|| Box::new(NoopMetrics{})).as_ref()
+}
+
 
 // Helper function to extract token count from response body JSON
 fn extract_token_count_from_response_body() -> Option<i64> {
@@ -164,46 +284,6 @@ fn extract_user_info() -> (String, String) {
     (user_id, group)
 }
 
-// Helper function to get or create a user/group specific metric with cleaner names
-fn get_or_create_user_group_metric(
-    metric_type: &str,
-    user: &str,
-    group: &str,
-    namespace: &str,
-) -> Option<u32> {
-    // Format: metric_type__user__USER__group__GROUP__namespace__NAMESPACE
-    let metric_name =
-        format!("{metric_type}__user__{user}__group__{group}__namespace__{namespace}");
-
-    let map_key = format!("{metric_type}:{user}:{group}:{namespace}");
-
-    unsafe {
-        if let Some(ref mut metrics_map) = USER_GROUP_METRICS {
-            if let Some(&metric_id) = metrics_map.get(&map_key) {
-                return Some(metric_id);
-            }
-
-            // Create new metric
-            match hostcalls::define_metric(proxy_wasm::types::MetricType::Counter, &metric_name) {
-                Ok(metric_id) => {
-                    metrics_map.insert(map_key, metric_id);
-                    Some(metric_id)
-                }
-                Err(e) => {
-                    error!(
-                        "Failed to define user/group metric {}: {:?}",
-                        metric_name, e
-                    );
-                    None
-                }
-            }
-        } else {
-            error!("User/group metrics not initialized");
-            None
-        }
-    }
-}
-
 fn extract_namespace_from_scope(scope: &str) -> String {
     if scope.contains('/') {
         scope.split('/').next().unwrap_or("default").to_string()
@@ -212,84 +292,16 @@ fn extract_namespace_from_scope(scope: &str) -> String {
     }
 }
 
-pub fn increment_authorized_calls_with_user_group(scope: &str) {
-    let (user_id, group) = extract_user_info();
-
-    if user_id == "unknown" || group == "unknown" {
-        return;
-    }
-
-    let namespace = extract_namespace_from_scope(scope);
-
-    if let Some(metric_id) = get_or_create_user_group_metric(
-        "authorized_calls_with_user_and_group",
-        &user_id,
-        &group,
-        &namespace,
-    ) {
-        match hostcalls::increment_metric(metric_id, 1) {
-            Ok(_) => {}
-            Err(e) => error!(
-                "Failed to increment authorized_calls_with_user_and_group: {:?}",
-                e
-            ),
-        }
-    }
-}
-
-pub fn increment_limited_calls_with_user_group(scope: &str) {
-    let (user_id, group) = extract_user_info();
-
-    if user_id == "unknown" || group == "unknown" {
-        return;
-    }
-
-    let namespace = extract_namespace_from_scope(scope);
-
-    if let Some(metric_id) = get_or_create_user_group_metric(
-        "limited_calls_with_user_and_group",
-        &user_id,
-        &group,
-        &namespace,
-    ) {
-        match hostcalls::increment_metric(metric_id, 1) {
-            Ok(_) => {}
-            Err(e) => error!(
-                "Failed to increment limited_calls_with_user_and_group: {:?}",
-                e
-            ),
-        }
-    }
-}
-
-pub fn increment_token_usage_with_user_group(tokens: i64, scope: &str) {
-    let (user_id, group) = extract_user_info();
-
-    if user_id == "unknown" || group == "unknown" {
-        return;
-    }
-
-    let namespace = extract_namespace_from_scope(scope);
-
-    if let Some(metric_id) = get_or_create_user_group_metric(
-        "token_usage_with_user_and_group",
-        &user_id,
-        &group,
-        &namespace,
-    ) {
-        match hostcalls::increment_metric(metric_id, tokens) {
-            Ok(_) => {}
-            Err(e) => error!(
-                "Failed to increment token_usage_with_user_and_group: {:?}",
-                e
-            ),
-        }
-    }
-}
-
 pub fn process_response_body_for_token_usage(scope: &str) {
-    if let Some(token_count) = extract_token_count_from_response_body() {
-        increment_token_usage(token_count);
-        increment_token_usage_with_user_group(token_count, scope);
+    let metrics = get_metrics();
+    if metrics.is_enabled() {
+        if let Some(token_count) = extract_token_count_from_response_body() {
+            metrics.increment_token_usage(scope, token_count);
+        }
     }
+}
+
+#[allow(dead_code)]
+pub fn initialize_metrics() {
+    METRICS.get_or_init(|| Box::new(HostMetrics::new()));
 }

--- a/src/ratelimit_action.rs
+++ b/src/ratelimit_action.rs
@@ -324,10 +324,7 @@ impl RateLimitAction {
                 debug!("process_response(rl): received OVER_LIMIT response");
 
                 // Increment limited calls metric
-                crate::metrics::increment_limited_calls();
-
-                // Increment user/group specific limited calls metric
-                crate::metrics::increment_limited_calls_with_user_group(&self.scope);
+                crate::metrics::get_metrics().increment_limited_calls(&self.scope);
 
                 Ok(DirectResponse::new(
                     StatusCode::TooManyRequests as u32,


### PR DESCRIPTION
Also, this could get rid of `initialize_metrics()` entirely by replacing all the `OnceLock::get` with `get_or_init`s in place... but maybe that's not desirable... 

I still need to ask a few question on the actual PR you opened... but what do you think of this approach?